### PR TITLE
Remove explicit-nulls from Build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,6 @@ lazy val root = project
     scalaVersion := "3.0.0-RC1",
     scalacOptions ++= Seq(
       "-Ycheck-init",
-      "-Yexplicit-nulls",
       "-Yindent-colons"
     ),
     


### PR DESCRIPTION
Explicit nulls are a nice feature, but there are quite a few bugs with the current implementation, some of which which I myself have filed in the dotty repo. They're undergoing a re-work of that feature, so we can re-enable when progress is made.

Resolves https://github.com/AugustNagro/native-converter/issues/7