### PR TITLE
revert to recursive implementation of derived methods

### DIFF
--- a/src/main/scala/org/getshaka/nativeconverter/ArrayProduct.scala
+++ b/src/main/scala/org/getshaka/nativeconverter/ArrayProduct.scala
@@ -1,6 +1,6 @@
 package org.getshaka.nativeconverter
 
-class ArrayProduct(arr: IArray[Any]) extends Product:
+class ArrayProduct(arr: Array[Any]) extends Product:
   override def productArity: Int = arr.length
 
   override def productElement(n: Int): Any = arr(n)

--- a/src/test/scala/JsonTests.scala
+++ b/src/test/scala/JsonTests.scala
@@ -284,4 +284,16 @@ class JsonTests:
   end literalTypeDerivations
    */
 
+
+  case class Node(children: List[Node]) derives NativeConverter
+
+  @Test
+  def recursiveTest: Unit =
+    val n = Node(List(Node(Nil), Node(Nil), Node(List(Node(Nil)))))
+    val json =
+      """ {"children":[{"children":[]},{"children":[]},{"children":[{"children":[]}]}]}  """.trim
+    assertEquals(json, n.toJson)
+    assertEquals(n, NativeConverter[Node].fromJson(json))
+
+
     


### PR DESCRIPTION
Fixes https://github.com/getshaka-org/native-converter/issues/16

In commit https://github.com/getshaka-org/native-converter/commit/7dd1a6b4d20a3f4e1f875a33d5c93c5b89b47a89 I changed the derivation to use `summonAll`, which make things simpler and probably a little faster.

But it doesn't work for recursive structures, and I can't think of a way to `summonAll` in a lazy way that's simpler then just reverting. No harm no foul!